### PR TITLE
Adding gid support for start_as and stop_as

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.5.3 / 2015-03-16
+
+* adding gid support for start_as and stop_as
+
 1.5.2 / 2015-03-15
 
 * add stop_as support

--- a/libraries/provider_monit_check.rb
+++ b/libraries/provider_monit_check.rb
@@ -52,9 +52,11 @@ class Chef
           :name => new_resource.name, :check_type => new_resource.check_type,
           :check_id => new_resource.check_id, :id_type => new_resource.id_type,
           :group => new_resource.group, :start_as => new_resource.start_as,
+          :start_as_group => new_resource.start_as_group, 
           :start => new_resource.start, :stop => new_resource.stop,
-          :stop_as => new_resource.stop_as, :every => new_resource.every,
-          :tests => new_resource.tests
+          :stop_as => new_resource.stop_as, 
+          :stop_as => new_resource.stop_as_group,
+          :every => new_resource.every, :tests => new_resource.tests
         }
       end
       # rubocop: enable AbcSize

--- a/libraries/resource_monit_check.rb
+++ b/libraries/resource_monit_check.rb
@@ -68,6 +68,13 @@ class Chef
         )
       end
 
+      def start_as_group(arg = nil)
+        set_or_return(
+          :start_as_group, arg,
+          :kind_of => String
+        )
+      end
+
       def start(arg = nil)
         set_or_return(
           :start, arg,
@@ -83,6 +90,13 @@ class Chef
       def stop_as(arg = nil)
         set_or_return(
           :stop_as, arg,
+          :kind_of => String
+        )
+      end
+
+      def stop_as_group(arg = nil)
+        set_or_return(
+          :stop_as_group, arg,
           :kind_of => String
         )
       end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'nath.e.will@gmail.com'
 license          'Apache 2.0'
 description      'Installs and configures monit'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.5.2'
+version          '1.5.3'
 
 depends 'yum-epel'
 depends 'ubuntu'

--- a/templates/default/monit.check.erb
+++ b/templates/default/monit.check.erb
@@ -12,13 +12,13 @@ check <%= @check_type %> <%= @name %>
 <% if @start %>
   start "<%= @start %>"
   <% if @start_as %>
-    as uid <%= @start_as %>
+    as uid <%= @start_as %> and gid <%= @start_as_group %>
   <% end %>
 <% end %>
 <% if @stop %>
   stop "<%= @stop %>"
   <% if @stop_as %>
-    as uid <%= @stop_as %>
+    as uid <%= @stop_as %> and gid <%= @stop_as_group %>
   <% end %>
 <% end %>
 <% @tests.each do |test| %>


### PR DESCRIPTION
Today at work we realized the lack of gid support for the Chef-based monit configs was actually having an affect on our production environment.  Your stop_as commit was extremely clear (I'm really, REALLY new to github) so I used that as an example to put it all together and see if I could get it setup properly as an actual pull request.

Thanks!