### PR TITLE
start/stop as uid should also require gid

### DIFF
--- a/libraries/resource_monit_check.rb
+++ b/libraries/resource_monit_check.rb
@@ -71,7 +71,8 @@ class Chef
       def start_as_group(arg = nil)
         set_or_return(
           :start_as_group, arg,
-          :kind_of => String
+          :kind_of => String,
+          :required => start_as
         )
       end
 
@@ -97,7 +98,8 @@ class Chef
       def stop_as_group(arg = nil)
         set_or_return(
           :stop_as_group, arg,
-          :kind_of => String
+          :kind_of => String,
+          :required => stop_as
         )
       end
 


### PR DESCRIPTION
require start_as_group and stop_as_group when specifying start_as and stop_as, related to https://github.com/bbg-cookbooks/monit-ng/pull/22#issuecomment-85251001