### PR TITLE
fully configurable alert recipients

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,24 +60,34 @@ provider for managing additional monit checks.
 
 * `default['monit']['config']['mail_message']` (default: `text`): email notification body
 
-* `default['monit']['config']['subscribers']` (default: `[]`): this attributes configures `set alert` config option for each `Hash` element (subscriber) with attribute `name` and `subscriptions`, e.g. chef role
+* `default['monit']['config']['alert']` (default: `[]`): this attributes configures `set alert` config option for each `Hash` element with attribute `email` and optional event filters
+Documentation for event filters can be found at https://mmonit.com/monit/documentation/monit.html#Setting-an-event-filter
 
+```
 	  "default_attributes": {
 	    "monit": {
 		  "config": {
-			"subscribers": [
+			"alert": [
 			  {
 			    "name": "root@localhost",
-			    "subscriptions": [ "nonexist", "timeout", "resource", "icmp", "connection"]
+			    "but_not_on": [ "nonexist" ]
+			  },
+			  {
+			    "name": "netadmin@localhost",
+			    "only_on": [ "nonexist", "timeout", "icmp", "connection"]
+			  },
+			  {
+			    "name": "iwantall@localhost",
 			  }
 			]
 		  }
 		}
 	  }
-
+```
 
 * `default['monit']['config']['mail_servers']` (default: `[]`): this attributes configures `set mailserver` config option for each `Hash` element (mail server) with below attributes, e.g. chef role
 
+```
 	  "default_attributes": {
 	    "monit": {
 		  "config": {
@@ -94,7 +104,7 @@ provider for managing additional monit checks.
 		  }
 		}
 	  }
-
+```
 
 
 ## monit_check resource examples

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ provider for managing additional monit checks.
 
 ## Dependencies
 
-- yum-epel
-- ubuntu
-- apt
-- build-essential
+- yum-epel (on rhel hosts)
+- ubuntu (on ubuntu hosts)
+- apt (on debian hosts)
+- build-essential (if installing from source)
 
 
 ## Attributes
@@ -44,7 +44,7 @@ provider for managing additional monit checks.
 
 * `default['monit']['config']['log_file']` (default: `/var/log/monit.log`): monit log file location
 
-* `default['monit']['config']['id_file']` (default: `/var/lib/monit.id`): mmonit system id file location
+* `default['monit']['config']['id_file']` (default: `/var/lib/monit.id`): monit system id file location
 
 * `default['monit']['config']['state_file']` (default: `/var/run/monit.state`): where to save state between startups
 
@@ -86,7 +86,7 @@ Documentation for event filters can be found at https://mmonit.com/monit/documen
 	  }
 ```
 
-* `default['monit']['config']['mail_servers']` (default: `[]`): this attributes configures `set mailserver` config option for each `Hash` element (mail server) with below attributes, e.g. chef role
+* `default['monit']['config']['mail_servers']` (default: `[]`): this attributes configures `set mailserver` config option for each `Hash` element (mail server) with below attributes:
 
 ```
 	  "default_attributes": {

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ provider for managing additional monit checks.
 
 * `default['monit']['config']['mail_message']` (default: `text`): email notification body
 
-* `default['monit']['config']['alert']` (default: `[]`): this attributes configures `set alert` config option for each `Hash` element with attribute `email` and optional event filters
+* `default['monit']['config']['alert']` (default: `[]`): this attributes configures `set alert` config option for each `Hash` element with attribute `name` and optional event filters  
+
 Documentation for event filters can be found at https://mmonit.com/monit/documentation/monit.html#Setting-an-event-filter
 
 ```

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -42,7 +42,7 @@ template monit['conf_file'] do # ~FC009
     :id_file => config['id_file'],
     :state_file => config['state_file'],
     :mail_servers => config['mail_servers'],
-    :subscribers => config['subscribers'],
+    :alert => config['alert'] || config['subscribers'],
     :eventqueue_dir => config['eventqueue_dir'],
     :eventqueue_slots => config['eventqueue_slots'],
     :listen => config['listen'],

--- a/templates/default/monit.conf.erb
+++ b/templates/default/monit.conf.erb
@@ -34,9 +34,15 @@ set mail-format {
    message: <%= @mail_msg %>
 }
 
-<% @subscribers.each do |subscriber| %>
-set alert <%= subscriber.name %>
-  only on { <%= subscriber.subscriptions.join(', ') %>}
+<% @alert.each do |alert| %>
+set alert <%= alert.name %>
+<% if ! alert.only_on.nil? -%>
+  only on { <%= alert.only_on.join(', ') %>}
+<% elsif ! alert.subscriptions.nil? -%>
+  only on { <%= alert.subscriptions.join(', ') %>}
+<% elsif ! alert.but_not_on.nil? -%>
+  but not on { <%= alert.but_not_on.join(', ') %>}
+<% end -%>
 
 <% end %>
 set eventqueue


### PR DESCRIPTION
Revised to allow alert recipients without filters, or with exclusions
Used names consistent with monit documentation, backwards compatible with old attributes

Minor fixes to the readme for clarity.