### PR TITLE
Remove fixed file logging installed by package if using syslog

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -9,3 +9,19 @@ include_recipe 'apt' if platform_family?('debian')
 include_recipe 'ubuntu' if platform?('ubuntu')
 
 package 'monit'
+
+# If using syslog, remove hardcoded file logging from the package
+if node['monit']['config']['log_file'] == 'syslog'
+  file '/etc/monit.d/logging' do
+    action :delete
+  end
+
+  file '/etc/logrotate.d/monit' do
+    action :delete
+  end
+
+  directory '/var/log/monit' do
+    action :delete
+    recursive true
+  end
+end


### PR DESCRIPTION
RHEL packages install a file to enable file logging, plus a directory for the logs and a log rotation script -- all of which are useless if you're using syslog. This removes those.

You may want to wrap this around platform rhel and/or have a config option control whether this is done.