### PR TITLE
monit_check service reload duplicated between ruby_block and provider

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -87,13 +87,6 @@ ruby_block 'reload-monit' do
   action :nothing
 end
 
-ruby_block 'notify-reload-monit' do
-  block do
-    Chef::Log.info('Running delayed notification of ruby_block[reload-monit]')
-  end
-  notifies :run, 'ruby_block[reload-monit]', :delayed
-end
-
 ruby_block 'notify-start-monit' do
   block do
   end


### PR DESCRIPTION
At this time monit reloads on every Chef run. That isn't optimal nor necessary.  Here it happens AFTER the service is restarted...

```
Recipe: monit-ng::config
  * service[monit] action restart
    - restart service service[monit]
  * ruby_block[reload-monit] action run
    - execute the ruby block reload-monit
  * service[monit] action start (up to date)
```