### PR TITLE
Add depends on service name attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Documentation for event filters can be found [here][filters].
 |stop_as_group|group to execute stop command as|nil|
 |stop|stop command|nil|
 |group|check group (e.g. "hosts")|nil|
+|depends|depends on named service (e.g. "apache")|nil|
 |tests|array of hashes with 'condition', 'action' keys, maps to monit if, then|[]|
 |every|string for args to "every" configuration (e.g. every n cycles, every "* 8-19 * * 1-5")|nil|
 |alert|email to alert|nil|

--- a/libraries/provider_monit_check.rb
+++ b/libraries/provider_monit_check.rb
@@ -60,7 +60,7 @@ class Chef
         {
           :name => new_resource.name, :check_type => new_resource.check_type,
           :check_id => new_resource.check_id, :id_type => new_resource.id_type,
-          :group => new_resource.group, :depend => new_resource.depends,
+          :group => new_resource.group, :depends => new_resource.depends,
           :start_as => new_resource.start_as,
           :start_as_group => new_resource.start_as_group,
           :start => new_resource.start, :stop => new_resource.stop,

--- a/libraries/provider_monit_check.rb
+++ b/libraries/provider_monit_check.rb
@@ -60,7 +60,8 @@ class Chef
         {
           :name => new_resource.name, :check_type => new_resource.check_type,
           :check_id => new_resource.check_id, :id_type => new_resource.id_type,
-          :group => new_resource.group, :start_as => new_resource.start_as,
+          :group => new_resource.group, :depend => new_resource.depends,
+          :start_as => new_resource.start_as,
           :start_as_group => new_resource.start_as_group,
           :start => new_resource.start, :stop => new_resource.stop,
           :stop_as => new_resource.stop_as,

--- a/libraries/resource_monit_check.rb
+++ b/libraries/resource_monit_check.rb
@@ -124,6 +124,13 @@ class Chef
         )
       end
 
+      def depends(arg = nil)
+        set_or_return(
+          :depends, arg,
+          :kind_of => String
+        )
+      end
+
       def tests(arg = nil)
         set_or_return(
           :tests, arg,

--- a/templates/default/monit.check.erb
+++ b/templates/default/monit.check.erb
@@ -12,6 +12,9 @@ check <%= @check_type %> <%= @name %>
 <% if @group %>
   group <%= @group %>
 <% end %>
+<% if @depends %>
+  depends on <%= @depends %>
+<% end %>
 <% if @start %>
   start "<%= @start %>"
   <% if @start_as %>

--- a/templates/default/monit.conf.erb
+++ b/templates/default/monit.conf.erb
@@ -50,7 +50,9 @@ set eventqueue
   slots <%= @eventqueue_slots %>
 
 set httpd port <%= @port %> and
+<% unless @listen.nil? -%>
   use address <%= @listen %>
+<% end -%>
   <% @allow.each do |allowed| %>
   allow <%= allowed %>
   <% end %>


### PR DESCRIPTION
A simple addition of `depends on` described under "SERVICE DEPENDENCIES" on https://mmonit.com/monit/documentation/monit.html

I also corrected the `@listens` to be optional allowing `default['monit']['config']['listen'] = nil` as per

> ADDRESS make Monit listen on a specific interface only. For example if you don't want to expose Monit's web interface to the network, bind it to localhost only. Monit will accept connections on any address by default (if ADDRESS option is missing).

Hope you find these useful