### PR TITLE
run monit reload if new check is added rather than service monit restart

### DIFF
--- a/recipes/reload.rb
+++ b/recipes/reload.rb
@@ -13,7 +13,10 @@ ruby_block 'conditional-monit-reload' do
     # Reload monit if any monit_check resources changed
     if checks.any?(&:updated_by_last_action?)
       Chef::Log.info('Found updated monit checks, issuing service reload.')
-      resources(:service => 'monit').run_action(:reload)
+
+      execute_reload = Chef::Resource::Execute.new('monit reload', run_context)
+      execute_reload.command 'monit reload'
+      execute_reload.run_action :nothing
     end
   end
   action :nothing


### PR DESCRIPTION
service monit reload only reloads the monit config if it has changed, but does not reload monit if new conf files have been added.  Thus, when one adds a check, service monit restart does nothing.  However, monit reload will reload the config and find new checks.
