### PR TITLE
Add custom matcher for monit_check LWRP

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,7 +1,7 @@
 # Matchers for ChefSpec 3
 
 if defined?(ChefSpec)
-  ChefSpec::Runner.define_runner_method(:monit_check)
+  ChefSpec.define_matcher(:monit_check)
 
   def create_monit_check(check)
     ChefSpec::Matchers::ResourceMatcher.new(:monit_check, :create, check)

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,6 +1,8 @@
 # Matchers for ChefSpec 3
 
 if defined?(ChefSpec)
+  ChefSpec::Runner.define_runner_method(:monit_check)
+
   def create_monit_check(check)
     ChefSpec::Matchers::ResourceMatcher.new(:monit_check, :create, check)
   end


### PR DESCRIPTION
Added a `monit_check` matcher. 

Use case: I might have a recipe that disables a monit_check and notifies a service to stop.

```ruby
monit_check 'foo' do
  check_id '/foo.pid'
  action :remove
  notifies :stop, 'service[bar]', :immediately
end
```

With the custom matcher, I can write a ChefSpec test that tests the notify behavior.

```ruby
it 'notifies bar to stop' do
  expect(chef_run.monit_check('foo')).to notify('service[bar]').to(:stop).immediately
end
```