### PR TITLE
Run a syntax check before starting monit via upstart

### DIFF
--- a/templates/default/monit.upstart.erb
+++ b/templates/default/monit.upstart.erb
@@ -9,6 +9,11 @@ stop on runlevel [!2345]
 expect daemon
 respawn
 
+pre-start script
+    test -x <%= @binary %> || { stop; exit 0; }
+    <%= @binary %> -t || { echo "invalid configuration syntax" ; stop; exit 0; }
+end script
+
 exec <%= @binary %> -c <%= @conf_file %>
 
 pre-stop exec <%= @binary %> -c <%= @conf_file %> quit

--- a/templates/default/monit.upstart.erb
+++ b/templates/default/monit.upstart.erb
@@ -10,8 +10,8 @@ expect daemon
 respawn
 
 pre-start script
-    test -x <%= @binary %> || { stop; exit 0; }
-    <%= @binary %> -t || { echo "invalid configuration syntax" ; stop; exit 0; }
+    test -x <%= @binary %> || { stop; exit 1; }
+    <%= @binary %> -t || { echo "invalid configuration syntax" ; stop; exit 1; }
 end script
 
 exec <%= @binary %> -c <%= @conf_file %>


### PR DESCRIPTION
I realise syntax check happens on Chef 12 via `verify` but this will help catch cases of other software mucking around with things too much