### PR TITLE
Have upstart wait for Monit to be up and running

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -95,6 +95,7 @@ when 'source'
       :platform_family => node['platform_family'],
       :binary          => monit_bin,
       :conf_file       => node['monit']['conf_file'],
+      :start_delay     => node['monit']['start_delay'],
     )
   end
 else

--- a/templates/default/monit.upstart.erb
+++ b/templates/default/monit.upstart.erb
@@ -17,3 +17,10 @@ end script
 exec <%= @binary %> -c <%= @conf_file %>
 
 pre-stop exec <%= @binary %> -c <%= @conf_file %> quit
+
+post-start script
+    echo "Waiting for Monit to be reachable"
+    while sleep <%= @start_delay %> ; do
+        <%= @binary %> status | grep -qv "error connecting to the monit daemon" && exit 0
+    done
+end script


### PR DESCRIPTION
grep has to be done since monit always exits with 0. -v is an inverse, so that means that it does exit 0 as soon as it stop seeing the error
Using start delay as it should be enough to only do one iteration but doing a loop just in case

This will allow Chef and other things to wait until Monit is actually contactable via the HTTP interface and ready to be used.