### PR TITLE
possibility to use monit built-in configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@ Documentation for event filters can be found [here][filters].
 }
 ```
 
+
+* `default['monit']['config']['built_in_configs']` (default: `[]`): this defines what built-in configuration files will be included
+
+```
+"default_attributes": {
+  "monit": {
+    "config": {
+      "built_in_configs": [
+        "memcached",
+        "nginx"
+      ]
+    }
+  }
+}
+```
+
 ## Resources
 
 ### monit_check

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -55,10 +55,9 @@ default['monit']['config'].tap do |conf|
   EOT
   conf['mail_servers'] = []
 
-  #monit built-in configuration files path
+  # monit built-in configuration files path
   conf['built_in_config_path'] = '/etc/monit/monitrc.d'
 
-  #what built-in configurations to load
+  # what built-in configurations to load
   conf['built_in_configs'] = []
-
 end

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -56,7 +56,7 @@ default['monit']['config'].tap do |conf|
   conf['mail_servers'] = []
 
   #monit built-in configuration files path
-  conf['built_in_config_path'] = 'monitrc.d'
+  conf['built_in_config_path'] = '/etc/monit/monitrc.d'
 
   #what built-in configurations to load
   conf['built_in_configs'] = []

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -54,4 +54,11 @@ default['monit']['config'].tap do |conf|
     monit
   EOT
   conf['mail_servers'] = []
+
+  #monit built-in configuration files path
+  conf['built_in_config_path'] = 'monitrc.d'
+
+  #what built-in configurations to load
+  conf['built_in_configs'] = []
+
 end

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -38,7 +38,7 @@ template monit['conf_file'] do # ~FC009
     :mmonit_url => config['mmonit_url'],
     :conf_dir => monit['conf_dir'],
     :built_in_config_path => config['built_in_config_path'],
-    :built_in_configs => config['built_in_configs']
+    :built_in_configs => config['built_in_configs'],
   )
   if Chef::VERSION.to_f >= 12
     verify do |path|

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -37,6 +37,8 @@ template monit['conf_file'] do # ~FC009
     :mail_msg => config['mail_message'],
     :mmonit_url => config['mmonit_url'],
     :conf_dir => monit['conf_dir'],
+    :built_in_config_path => config['built_in_config_path'],
+    :built_in_configs => config['built_in_configs']
   )
   if Chef::VERSION.to_f >= 12
     verify do |path|

--- a/templates/default/monit.conf.erb
+++ b/templates/default/monit.conf.erb
@@ -61,4 +61,11 @@ set httpd port <%= @port %> and
 set mmonit <%= @mmonit_url %>
 
 <% end %>
+
+<% @built_in_configs.each do |config| %>
+
+  include <%= @conf_dir %>/<%= @built_in_config_path %>/<%= config %>
+
+<% end %>
+
 include <%= @conf_dir %>/*.conf

--- a/templates/default/monit.conf.erb
+++ b/templates/default/monit.conf.erb
@@ -64,7 +64,7 @@ set mmonit <%= @mmonit_url %>
 
 <% @built_in_configs.each do |config| %>
 
-  include <%= @conf_dir %>/<%= @built_in_config_path %>/<%= config %>
+  include <%= @built_in_config_path %>/<%= config %>
 
 <% end %>
 


### PR DESCRIPTION
This adds the possibility to use monit built-in configuration files in monitrc.d folder. In some cases they are sufficient.