### PR TITLE
When using both "timeout" and "as user" the "as user" has to come first

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'nath.e.will@gmail.com'
 license          'Apache 2.0'
 description      'Installs and configures monit'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.2.0'
+version          '2.2.1'
 
 %w( yum-epel ubuntu apt build-essential dpkg_autostart ).each do |dep|
   depends dep

--- a/templates/default/monit.check.erb
+++ b/templates/default/monit.check.erb
@@ -16,15 +16,21 @@ check <%= @check_type %> <%= @name %>
   depends on <%= @depends %>
 <% end %>
 <% if @start %>
-  start "<%= @start %>" <%= "with timeout #{@start_timeout} seconds" if @start_timeout %>
+  start "<%= @start %>" 
   <% if @start_as %>
     as uid <%= @start_as %> and gid <%= @start_as_group %>
   <% end %>
+  <% if @start_timeout %>
+    with timeout <%=@start_timeout%> seconds
+  <% end %>
 <% end %>
 <% if @stop %>
-  stop "<%= @stop %>" <%= "with timeout #{@stop_timeout} seconds" if @stop_timeout %>
+  stop "<%= @stop %>" 
   <% if @stop_as %>
     as uid <%= @stop_as %> and gid <%= @stop_as_group %>
+  <% end %>
+  <% if @stop_timeout %>
+    with timeout <%= @stop_timeout %> seconds
   <% end %>
 <% end %>
 <% @tests.each do |test| %>


### PR DESCRIPTION
When using both the "timeout" setting and the "as user" setting, the 'as user' setting has to come first in the config or monit throws an error.  This pull adjusts the template so that is adjusted.