### PR TITLE
Support for Ubuntu 16.04 LTS

### DIFF
--- a/templates/default/monit.default.erb
+++ b/templates/default/monit.default.erb
@@ -4,7 +4,7 @@
   <% case @platform_version %>
   <% when '10.04' %>
 startup=1
-  <% when '12.04', '14.04' %>
+  <% else %>
 START=yes
   <% end %>
 <% when 'debian' %>


### PR DESCRIPTION
Monit was not starting in the upcoming Ubuntu 16.04 LTS, since it was not explicitly inserted in the whitelist inside the template.