### PR TITLE
Allow an array as a group attribute for `monit_check`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ rvm:
 - 2.0.0
 - 2.1.5
 - 2.2.2
+- 2.3.0
 
 script: bundle exec rake default

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
     net-ssh-multi (1.2.1)
       net-ssh (>= 2.6.5)
       net-ssh-gateway (>= 1.2.0)
-    nio4r (1.1.0)
+    nio4r (1.2.1)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     octokit (3.8.0)
@@ -248,4 +248,4 @@ DEPENDENCIES
   test-kitchen
 
 BUNDLED WITH
-   1.10.3
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Documentation for event filters can be found [here][filters].
 |stop_as|user to execute stop command as|nil|
 |stop_as_group|group to execute stop command as|nil|
 |stop|stop command|nil|
-|group|check group (e.g. "hosts")|nil|
+|group|check group(s) (e.g. "hosts" or ["hosts", "apis"])|[]|
 |depends|depends on named service (e.g. "apache")|nil|
 |tests|array of hashes with 'condition', 'action' keys, maps to monit if, then|[]|
 |every|string for args to "every" configuration (e.g. every n cycles, every "* 8-19 * * 1-5")|nil|

--- a/libraries/monit_check.rb
+++ b/libraries/monit_check.rb
@@ -29,7 +29,7 @@ class Chef::Resource
     attribute :start_timeout, kind_of: [String, Integer]
     attribute :stop_as, kind_of: String
     attribute :stop_timeout, kind_of: [String, Integer]
-    attribute :group, kind_of: String
+    attribute :group, kind_of: [Array, String], default: []
     attribute :depends, kind_of: String
     attribute :tests, kind_of: Array, default: []
     attribute :every, kind_of: String

--- a/templates/default/monit.check.erb
+++ b/templates/default/monit.check.erb
@@ -9,14 +9,18 @@ check <%= @check_type %> <%= @name %>
 <% if @alert %>
   alert <%= @alert %> <% if @but_not_on %>but not on<% else %>on<% end %> { <%= @alert_events.join(', ') %> }
 <% end %>
-<% if @group %>
+<% if @group.is_a?(String)
   group <%= @group %>
+<% elsif @group.is_a?(Array) %>
+  <% @group.each do |group| %>
+  group <%= group %>
+  <% end %>
 <% end %>
 <% if @depends %>
   depends on <%= @depends %>
 <% end %>
 <% if @start %>
-  start "<%= @start %>" 
+  start "<%= @start %>"
   <% if @start_as %>
     as uid <%= @start_as %> and gid <%= @start_as_group %>
   <% end %>
@@ -25,7 +29,7 @@ check <%= @check_type %> <%= @name %>
   <% end %>
 <% end %>
 <% if @stop %>
-  stop "<%= @stop %>" 
+  stop "<%= @stop %>"
   <% if @stop_as %>
     as uid <%= @stop_as %> and gid <%= @stop_as_group %>
   <% end %>

--- a/test/fixtures/cookbooks/setup/recipes/default.rb
+++ b/test/fixtures/cookbooks/setup/recipes/default.rb
@@ -1,5 +1,3 @@
-
-
 include_recipe 'monit-ng'
 
 monit_check node.name do

--- a/test/integration/repo/serverspec/localhost/monit_spec.rb
+++ b/test/integration/repo/serverspec/localhost/monit_spec.rb
@@ -25,7 +25,6 @@ describe 'Monit Daemon' do
     end
   end
 
-  
   conf_dir, conf_file = case os[:family]
                         when 'redhat'
                           ['/etc/monit.d', '/etc/monit.conf']


### PR DESCRIPTION
[Closes #60]

I saw `test` directory with some specs for template, but I have no experience with testing chef cookbooks. I am not sure how can I run them. Default rake task is using only specs under the `spec` directory. I will add them if you could give me some tips on this topic.

I have added ruby 2.3.0 to travis and bumped nio4r to make it work.