### PR TITLE
Add status as supported action to service resource

### DIFF
--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -27,6 +27,7 @@ service 'monit' do
   action [:enable]
   subscribes :restart, "template[#{node['monit']['conf_file']}]", :delayed
   subscribes :restart, 'template[/etc/default/monit]', :delayed
+  supports status: true
   not_if { node['monit']['skip_service'] }
 end
 


### PR DESCRIPTION
According to the documentation monit supports `status`, but the default
options with the chef service resource does not enable it.

ref:
https://mmonit.com/monit/documentation/monit.html

fixes: #64 