### PR TITLE
Add option to disable log file

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,6 +9,7 @@ platforms:
   - name: debian-8.2
   - name: ubuntu-12.04
   - name: ubuntu-14.04
+  - name: ubuntu-16.04
   - name: centos-6.7
   - name: centos-7.2
 

--- a/templates/default/monit.conf.erb
+++ b/templates/default/monit.conf.erb
@@ -2,7 +2,9 @@
 set daemon <%= @poll_freq %>
   with start delay <%= @start_delay %>
 
+<% if @log_file %>
 set logfile <%= @log_file %>
+<% end %>
 
 set idfile <%= @id_file %>
 


### PR DESCRIPTION
On ubuntu 16.04 (probably other systemd distributions too), I've
noticed that monit logs are doubled. Disabling log file and leaving
logging to systemd helps.

I've also added Ubuntu 16.04 to supported platrforms.